### PR TITLE
chore(conf): change editorconfig indentation rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ charset = utf-8
 end_of_line = lf
 
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 insert_final_newline = true
 max_line_length = 120
@@ -15,3 +15,4 @@ trim_trailing_whitespace = true
 
 [Makefile]
 indent_style = tab
+indent_size = 4


### PR DESCRIPTION
# Description

update indentation rules
- [x] `*`:  `4 spaces` -> `2 spaces`
- [x] `Makefile`:  `tabs`

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | no
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | ~
| License        | MIT
