### PR TITLE
chore(cs): remove useless strict rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,5 +12,3 @@ rules:
   import/no-extraneous-dependencies:
     - error:
       devDependencies: true
-  strict:
-    - error


### PR DESCRIPTION
# Description

remove useless `strict` rule in eslint config

---

| Q              | A
| -------------- | ---
| Bug fix ?      | no
| New feature ?  | no
| BC breaks ?    | no
| Deprecations ? | no
| Tests pass ?   | yes
| Fixed tickets  | ~
| License        | MIT
